### PR TITLE
Add Xcode format and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# VerifyNoBS (Build Settings)
+
+This script is meant to be called from an Xcode run script build phase.
+It verifies there are no buildSettings embedded in the Xcode project as it is preferable to have build settings specified in .xcconfig files.
+
+## How to use:
+Put this script in a folder called 'buildscripts' next to your xcode project.
+Then, add a "Run Script Build Phase" to one of your targets with this as the script
+
+    xcrun -sdk macosx swift buildscripts/VerifyNoBS.swift  --xcode  ${PROJECT_DIR}/${PROJECT_NAME}.xcodeproj/project.pbxproj
+
+This will run the script and fail your build if any build settings are detected in your project file.
+The `--xcode` switch will output any errors in a format that is picked up by Xcode so you can directly click on the error and jump to the offending spot in the project file.
+
+When running it without the `--xcode` switch errors will simply be written to stderr.

--- a/VerifyNoBS.swift
+++ b/VerifyNoBS.swift
@@ -8,84 +8,148 @@
 // Put this script in a folder called 'buildscripts' next to your xcode project
 // Then, add a Run script build phase to one of your targets with this as the script
 //
-//   xcrun -sdk macosx swiftc -target x86_64-macosx10.11  buildscripts/VerifyNoBS.swift -o $CONFIGURATION_TEMP_DIR/VerifyNoBS
-//   $CONFIGURATION_TEMP_DIR/VerifyNoBS ${PROJECT_NAME}.xcodeproj/project.pbxproj
+//   xcrun -sdk macosx swift buildscripts/VerifyNoBS.swift  --xcode  ${PROJECT_DIR}/${PROJECT_NAME}.xcodeproj/project.pbxproj
 //
-// The first line, beginning with 'xcrun', tells the swift compiler ('swiftc') to compile the file buildscripts/VerifyNoBS.swift
-// and output the resulting executable to the folder $CONFIGURATION_TEMP_DIR in an executable file called VerifyNoBS
-// The second line executes that executable, with a command line arg pointing to the current .xcodeproj file
 
 import Darwin
 import Foundation
 
-func reportError(message: String) {
-    print("error message was \(message)")
-    let stderr = FileHandle.standardError
-    if let data = message.data(using: String.Encoding.utf8, allowLossyConversion: false) {
-        stderr.write(data)
-    } else {
-        print("there was an error.  Could not convert error message to printable string")
-    }
+/// A message with its file name and location
+struct LocatedMessage {
+    let message: String
+    let fileUrl: URL
+    let line: Int
 }
 
-public enum ProcessXcodeprojResult {
-    case FoundBuildSettings([String])
-    case Error(String)
-    case OK(String)
-}
-
-public func processXcodeprojAt(url: URL) -> ProcessXcodeprojResult {
-    let startTime = Date()
-    guard let xcodeproj = try? String(contentsOf: url, encoding: String.Encoding.utf8) else {
-        return .Error("failed making xcodeproj from url")
+/// Utility to process the pbxproj file
+struct BuildSettingsVerifier {
+    
+    public enum ProcessXcodeprojResult {
+        case foundBuildSettings([LocatedMessage])
+        case error(String)
+        case success(String)
     }
-    let lines = xcodeproj.components(separatedBy: CharacterSet.newlines)
-    print ("found \(lines.count) lines")
-
-    var badLines: [String] = []
-    var inBuildSettingsBlock = false
-    for nthLine in lines {
-        if inBuildSettingsBlock {
-            if let _ = nthLine.range(of:"\\u007d[:space:]*;", options: .regularExpression) {
-                inBuildSettingsBlock = false
-            } else if let _ = nthLine.range(of:"CODE_SIGN_IDENTITY") {
-
+    
+    /// Mode to run the utility in. Mode defines the output format
+    public enum Mode {
+        /// Write errors to stderr
+        case cmd
+        /// Write errors to stdout in a format that is picked up by Xcode
+        case xcode
+    }
+    
+    /// The mode to run in
+    let mode: Mode
+    
+    /// The absolute file URL to the pbxproj file
+    let projUrl: URL
+    
+    init(mode: Mode, projUrl: URL) {
+        self.mode = mode
+        self.projUrl = projUrl
+    }
+    
+    /// Reports an error either to stderr or to stdout, depending on the mode
+    func reportError(message: String, fileUrl: URL? = nil, line: Int? = nil) {
+        switch mode {
+        case .cmd:
+            let stderr = FileHandle.standardError
+            if let data = "\(message)\n".data(using: String.Encoding.utf8, allowLossyConversion: false) {
+                stderr.write(data)
             } else {
-                badLines.append(nthLine)
+                print("There was an error.  Could not convert error message to printable string")
             }
-        } else {
-            if let _ = nthLine.range(of:"buildSettings[:space:]*=", options: .regularExpression) {
-                inBuildSettingsBlock = true
+        case .xcode:
+            var messageParts = [String]()
+            
+            if let fileUrl = fileUrl {
+                messageParts.append("\(fileUrl.path):")
             }
+            
+            if let line = line {
+                messageParts.append("\(line): ")
+            }
+            
+            messageParts.append("error: \(message)")
+            
+            print(messageParts.joined())
         }
     }
 
-    let timeInterval = Date().timeIntervalSince(startTime)
-    print ("process took \(timeInterval) seconds")
-    if (badLines.count > 0) {
-        return .FoundBuildSettings(badLines)
+    /// Inspect the pbxproj file for non-empty buildSettings
+    func processXcodeprojAt(url: URL) -> ProcessXcodeprojResult {
+        let startTime = Date()
+        guard let xcodeproj = try? String(contentsOf: url, encoding: String.Encoding.utf8) else {
+            return .error("Failed to read xcodeproj contents from \(url)")
+        }
+        let lines = xcodeproj.components(separatedBy: CharacterSet.newlines)
+        print("Found \(lines.count) lines")
+
+        var locatedMessages: [LocatedMessage] = []
+        var inBuildSettingsBlock = false
+        for (lineIndex, nthLine) in lines.enumerated() {
+            if inBuildSettingsBlock {
+                if nthLine.range(of: "\\u007d[:space:]*;", options: .regularExpression) != nil {
+                    inBuildSettingsBlock = false
+                } else if nthLine.range(of: "CODE_SIGN_IDENTITY") != nil {
+
+                } else {
+                    let message = mode == .cmd ? "    \(nthLine)\n" : "Setting '\(nthLine.trimmingCharacters(in: .whitespacesAndNewlines))' should be in an xcconfig file"
+                    locatedMessages.append(LocatedMessage(
+                        message: message,
+                        fileUrl: url,
+                        line: lineIndex + 1
+                    ))
+                }
+            } else {
+                if nthLine.range(of: "buildSettings[:space:]*=", options: .regularExpression) != nil {
+                    inBuildSettingsBlock = true
+                }
+            }
+        }
+
+        let timeInterval = Date().timeIntervalSince(startTime)
+        print("Process took \(timeInterval) seconds")
+        if locatedMessages.count > 0 {
+            return .foundBuildSettings(locatedMessages)
+        }
+        return .success(":-)")
     }
-    return .OK(":-)")
+    
+    public func verify() -> Int32 {
+        print("Verifying there are no build settings...")
+        
+        let result = processXcodeprojAt(url: projUrl)
+
+        switch result {
+        case .error(let str):
+            reportError(message: "Error verifying build settings: \(str)")
+            return EXIT_FAILURE
+        case .foundBuildSettings(let locatedMessages):
+            reportError(message: "Found build settings in project file")
+            for msg in locatedMessages {
+                reportError(message: msg.message, fileUrl: msg.fileUrl, line: msg.line)
+            }
+            return EXIT_FAILURE
+        case .success:
+            print("No build settings found in project file")
+            return EXIT_SUCCESS
+        }
+    }
 }
-print("Verifying no buildSettings...")
 
-let commandLineArgs = CommandLine.arguments
-print("processArgs were \(commandLineArgs)")
-let xcodeprojfilepath = commandLineArgs[1]
-let myUrl = URL(fileURLWithPath:xcodeprojfilepath)
-let result = processXcodeprojAt(url: myUrl)
+var commandLineArgs = CommandLine.arguments.dropFirst()
+//print("processArgs were \(commandLineArgs)")
 
-switch result {
-    case .Error(let str):
-        reportError (message: "error verifying build settings: \(str)")
-        exit(EXIT_FAILURE)
-    case .FoundBuildSettings(let badLines):
-        reportError (message: "found buildSettings:")
-        for badLine in badLines {
-            reportError (message: "    \(badLine)\n")
-        }
-        exit(EXIT_FAILURE)
-    case .OK:
-        print ("Verified no buildSettings")
-        exit(EXIT_SUCCESS)
+if commandLineArgs.count < 1 {
+    print("Usage: \(#file) [--xcode] /path/to/Project.xcodeproj/project.pbxproj")
+    exit(EXIT_FAILURE)
+} else {
+    let xcodeProjFilePath = commandLineArgs.removeLast()
+    let mode: BuildSettingsVerifier.Mode = commandLineArgs.count > 0 && commandLineArgs.last == "--xcode" ? .xcode : .cmd
+    let myUrl = URL(fileURLWithPath: xcodeProjFilePath)
+    let verifier = BuildSettingsVerifier(mode: mode, projUrl: myUrl)
+    let exitCode = verifier.verify()
+
+    exit(exitCode)
 }


### PR DESCRIPTION
This commit adds a `--xcode` option to the tool that outputs errors in this
format:

    file:line: error: message

That format is picked up by Xcode and errors are displayed right in the UI,
allowing you to click on the error and jump directly to the offending line
in the project file.

Also added a Readme.